### PR TITLE
socket is not resource but socket object

### DIFF
--- a/src/transport/Socket.php
+++ b/src/transport/Socket.php
@@ -266,7 +266,7 @@ class Socket
      */
     public function isOpen(): bool
     {
-        if (!is_resource($this->socket)) {
+        if (!is_resource($this->socket) && !$this->socket instanceof \Socket) {
             return false;
         }
 


### PR DESCRIPTION
More information can be found here: https://php.watch/versions/8.0/sockets-sockets-addressinfo#sockets-is-resource

Note: this fix with backward compatibility.