### PR TITLE
Use cached CSMS reference.

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -711,7 +711,7 @@ class Client implements SmppClientInterface
                 $partCount = count($parts);
                 foreach ($parts as $part) {
                     $userDataHeader = pack(
-                        'cccccc',
+                        'CCCCCC',
                         5,
                         0,
                         3,


### PR DESCRIPTION
C-SMS with CSMS_8BIT_UDH got inconsistent csmsReferences over its parts.

Fixed by storing the value in a variable and passing it in the loop. 